### PR TITLE
Add MIT LICENSE file and license field to package.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 
 !/.env.dist
 !/.gitignore
+!/LICENSE
 !/package.json
 !/README.md
 !/server.mjs

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 André Ladmann
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
         "openai"
     ],
     "author": "André Ladmann",
+    "license": "MIT",
     "dependencies": {
         "dotenv": "^16.0.3",
         "express": "^4.18.2",


### PR DESCRIPTION
## Summary
- The README already stated `License: MIT`, but there was no `LICENSE` file in the repo and no `license` field in `package.json`, so GitHub and npm/yarn tooling could not detect the license.
- Added a standard `LICENSE` file with the MIT license text (copyright André Ladmann, 2026).
- Added `"license": "MIT"` to `package.json`.
- `.gitignore` uses an allow-list pattern (`/*` plus explicit `!/...` entries), so `!/LICENSE` was added to un-ignore the new file.

## Test plan
- [x] Verified no `LICENSE` file existed previously (locally and via GitHub API)
- [x] Verified `package.json` had no `license` field
- [x] `LICENSE` file added with standard MIT text
- [x] `package.json` updated with `license` field
- [x] `.gitignore` updated so `LICENSE` is tracked


---
_Generated by [Claude Code](https://claude.ai/code/session_01Lp4NfQNkSSsidndT28fKkk)_